### PR TITLE
Integration with editor intellisense

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,9 +31,9 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "playcanvas": "^1.55.4",
+    "playcanvas": "^1.59.0",
     "playcanvas-sync": "git+https://github.com/playcanvas/playcanvas-sync.git",
-    "typescript": "^4.7.4"
+    "typescript": "^4.9.4"
   },
   "dependencies": {
     "tsc-watch": "^5.0.3"

--- a/src/helloworld.ts
+++ b/src/helloworld.ts
@@ -1,10 +1,13 @@
 class HelloWorld extends pc.ScriptType {
     text: string;
+    entityLink : pc.Entity;
 
     initialize() {
         console.log('Hello ' + this.text);
+        console.log('Hello entity' + this.entityLink) // autocompletes fine
     }
 };
 
 pc.registerScript(HelloWorld, 'helloWorld');
 HelloWorld.attributes.add('text', {type: 'string'});
+HelloWorld.attributes.add('entityLink', {type : 'entity'})

--- a/src/helloworld.ts
+++ b/src/helloworld.ts
@@ -4,7 +4,6 @@ class HelloWorld extends pc.ScriptType {
 
     initialize() {
         console.log('Hello ' + this.text);
-        console.log('Hello entity' + this.entityLink) // autocompletes fine
     }
 };
 

--- a/tsconfig.debug.json
+++ b/tsconfig.debug.json
@@ -13,6 +13,7 @@
     "types": [
       "playcanvas"
     ],
+    "typeRoots": ["./types/"],
     "esModuleInterop": true, 
     "inlineSourceMap": true, 
     "inlineSources": true,   

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -1,0 +1,4 @@
+import * as _pc from 'playcanvas'
+declare global {
+    const pc : typeof _pc;
+}


### PR DESCRIPTION
This template is very good starting point, however I found that vscode or webstorm was not able to properly check or autocomplete library types (pc.*)

So I used examples from my previous experiments to enable completion and intellisense for playcanvas specifically.

This should work fine with vs code and webstorm.