### PR TITLE
Fix TypeScript errors

### DIFF
--- a/tsconfig.debug.json
+++ b/tsconfig.debug.json
@@ -8,12 +8,13 @@
       "ES2017"
     ],
     "outFile": "./build/main.build.js",
-    "rootDir": "./src",               
-    "strict": true, 
+    "rootDir": "./src",
+    "strict": true,
     "strictPropertyInitialization": false,
-    "esModuleInterop": true, 
-    "inlineSourceMap": true, 
-    "inlineSources": true,   
+    "types": ["playcanvas", "webxr"],
+    "esModuleInterop": true,
+    "inlineSourceMap": true,
+    "inlineSources": true,
     "experimentalDecorators": true,
     "forceConsistentCasingInFileNames": true
   }

--- a/tsconfig.release.json
+++ b/tsconfig.release.json
@@ -6,13 +6,14 @@
     "lib": [
       "DOM",
       "ES2017"
-    ], 
+    ],
     "outFile": "./build/main.build.js",
-    "rootDir": "./src",                
-    "strict": true, 
+    "rootDir": "./src",
+    "strict": true,
     "strictPropertyInitialization": false, 
+    "types": ["playcanvas", "webxr"],
     "esModuleInterop": true,
-    "experimentalDecorators": true, 
+    "experimentalDecorators": true,
     "forceConsistentCasingInFileNames": true
   }
 }

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -1,4 +1,0 @@
-import * as _pc from 'playcanvas'
-declare global {
-    const pc : typeof _pc;
-}


### PR DESCRIPTION
Correctly specify required typings to both VS Code and `tsc` on the command line.